### PR TITLE
Utilize emitted file list instead of hard-coding

### DIFF
--- a/tools/src/main/scala/caliban/tools/Codegen.scala
+++ b/tools/src/main/scala/caliban/tools/Codegen.scala
@@ -18,7 +18,7 @@ object Codegen {
   def generate(
     arguments: Options,
     genType: GenType
-  ): Task[Unit] = {
+  ): Task[List[File]] = {
     val s                  = ".*/[scala|play.*|app][^/]*/(.*)/(.*).scala".r.findFirstMatchIn(arguments.toPath)
     val packageName        = arguments.packageName.orElse(s.map(_.group(1).split("/").mkString(".")))
     val objectName         = s.map(_.group(2)).getOrElse("Client")
@@ -46,14 +46,15 @@ object Codegen {
                        )
                    }
       formatted <- if (enableFmt) Formatter.format(code, arguments.fmtPath) else Task.succeed(code)
-      _         <- Task.collectAll(formatted.map { case (objectName, objectCode) =>
+      paths     <- Task.collectAll(formatted.map { case (objectName, objectCode) =>
                      val path =
                        if (splitFiles) s"${arguments.toPath.reverse.dropWhile(_ != '/').reverse}$objectName.scala"
                        else arguments.toPath
                      Task(new PrintWriter(new File(path)))
                        .bracket(q => UIO(q.close()), pw => Task(pw.println(objectCode)))
+                       .as(new File(path))
                    })
-    } yield ()
+    } yield paths
   }
 
   private def getSchemaLoader(path: String, schemaPathHeaders: Option[List[Options.Header]]): SchemaLoader =


### PR DESCRIPTION
Without this, sbt-generated files do not get picked up during compilation, due to the only emitted output is just a single, hard-coded name.

Example error:

```
[error] IO error while decoding .../target/scala-2.13/src_managed/main/caliban-codegen-sbt/com/example/Service.scala with UTF-8: .../target/scala-2.13/src_managed/main/caliban-codegen-sbt/com/example/Service.scala (No such file or directory)
[error] Please try specifying another one using the -encoding option
```